### PR TITLE
ci: add Super-Linter and restore notify-on-failure job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,3 +205,65 @@ jobs:
           echo "Commit SHA: ${{ github.sha }}"
           echo "Branch: ${{ github.ref_name }}"
           echo "Run ID: ${{ github.run_id }}"
+
+# ── Job 4: Super-Linter ───────────────────────────────────────────────
+  lint:
+    name: Super-Linter
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Run Super-Linter
+        uses: super-linter/super-linter@v7
+        env:
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_CSHARP: true
+          VALIDATE_YAML: true
+          VALIDATE_JSON: true
+          VALIDATE_MARKDOWN: false
+          FILTER_REGEX_EXCLUDE: '.*Migrations/.*'
+
+  # ── Job 5: Notify on Failure ──────────────────────────────────────────
+  notify-on-failure:
+    name: Create Issue on CI Failure
+    runs-on: ubuntu-latest
+    needs: [build-and-test, security-scan, publish, lint]
+    if: failure() && github.ref == 'refs/heads/main'
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Create failure issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: ['ci-failure']
+            });
+
+            const duplicate = issues.find(i =>
+              i.title.includes(context.sha.substring(0, 7))
+            );
+
+            if (!duplicate) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `CI failure on main — ${context.sha.substring(0, 7)}`,
+                body: `## CI Pipeline Failure\n\n**Branch:** \`${context.ref}\`\n**Commit:** \`${context.sha}\`\n**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nOne or more CI jobs failed on the main branch. Please investigate and resolve before the next deployment.\n`,
+                labels: ['ci-failure', 'bug']
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,6 @@ jobs:
           VALIDATE_CSHARP: true
           VALIDATE_YAML: true
           VALIDATE_JSON: true
-          VALIDATE_MARKDOWN: false
           FILTER_REGEX_EXCLUDE: '.*Migrations/.*'
 
   # ── Job 5: Notify on Failure ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
add Super-Linter and restore notify-on-failure job


## Related issue
<!-- Reference the issue this PR addresses -->
Closes #

## Type of change
- [ ] New feature (non-breaking change adding functionality)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [x] CI/CD / configuration change

## Changes made
<!-- List the key changes in this PR -->
- 

## Screenshots
<!-- If this PR includes UI changes, add a screenshot here -->

## Checklist
- [ ] Code builds without errors (`dotnet build`)
- [ ] All unit tests pass (`dotnet test`)
- [ ] No hardcoded secrets, connection strings, or API keys
- [ ] No `*.db` database files committed
- [ ] Linked to the relevant GitHub issue above
- [ ] Commit messages follow the `feat:` / `fix:` / `chore:` convention
