### PR TITLE
chore: add Dependabot for automated NuGet and Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: "/Logbook"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "nuget"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary
chore: add Dependabot for automated NuGet and Actions updates


## Related issue
<!-- Reference the issue this PR addresses -->
Closes #

## Type of change
- [ ] New feature (non-breaking change adding functionality)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] CI/CD / configuration change

## Changes made
<!-- List the key changes in this PR -->
- 

## Screenshots
<!-- If this PR includes UI changes, add a screenshot here -->

## Checklist
- [ ] Code builds without errors (`dotnet build`)
- [ ] All unit tests pass (`dotnet test`)
- [ ] No hardcoded secrets, connection strings, or API keys
- [ ] No `*.db` database files committed
- [ ] Linked to the relevant GitHub issue above
- [ ] Commit messages follow the `feat:` / `fix:` / `chore:` convention
