### PR TITLE
fix: graceful degradation when Anthropic API key is not configured

### DIFF
--- a/Logbook/Services/AiExtractionService.cs
+++ b/Logbook/Services/AiExtractionService.cs
@@ -20,8 +20,7 @@ public class AiExtractionService : IAiExtractionService
         ILogger<AiExtractionService> logger)
     {
         _httpClient = httpClient;
-        _apiKey = configuration["Anthropic:ApiKey"]
-            ?? throw new InvalidOperationException("Anthropic:ApiKey is not configured.");
+        _apiKey = configuration["Anthropic:ApiKey"];
         _logger = logger;
     }
 
@@ -89,6 +88,11 @@ public class AiExtractionService : IAiExtractionService
 
     private async Task<ExtractionResult> CallClaudeAsync(string content, string? detectedSource)
     {
+        if (string.IsNullOrEmpty(_apiKey))
+        {
+            return new ExtractionResult(null, null, null, null, false,
+                "AI extraction is not configured. Please add an Anthropic API key.");
+        }
         var sourceHint = detectedSource != null ? $"The listing was found on: {detectedSource}" : "";
         var prompt = "Extract job listing information from the following content.\n" +
                      "Return ONLY a valid JSON object with exactly these fields, no other text, no markdown:\n" +


### PR DESCRIPTION
## Summary
graceful degradation when Anthropic API key is not configured


## Related issue
<!-- Reference the issue this PR addresses -->
Closes #

## Type of change
- [ ] New feature (non-breaking change adding functionality)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] CI/CD / configuration change

## Changes made
<!-- List the key changes in this PR -->
- 

## Screenshots
<!-- If this PR includes UI changes, add a screenshot here -->

## Checklist
- [ ] Code builds without errors (`dotnet build`)
- [ ] All unit tests pass (`dotnet test`)
- [ ] No hardcoded secrets, connection strings, or API keys
- [ ] No `*.db` database files committed
- [ ] Linked to the relevant GitHub issue above
- [ ] Commit messages follow the `feat:` / `fix:` / `chore:` convention
