### PR TITLE
fix: resolve nullable warning on ApiKey field in AiExtractionService

### DIFF
--- a/Logbook/Services/AiExtractionService.cs
+++ b/Logbook/Services/AiExtractionService.cs
@@ -8,7 +8,7 @@ namespace Logbook.Services;
 public class AiExtractionService : IAiExtractionService
 {
     private readonly HttpClient _httpClient;
-    private readonly string _apiKey;
+    private readonly string? _apiKey;
     private readonly ILogger<AiExtractionService> _logger;
 
     private const string ApiUrl = "https://api.anthropic.com/v1/messages";


### PR DESCRIPTION
## Summary
fix: resolve nullable warning on ApiKey field in AiExtractionService


## Related issue
<!-- Reference the issue this PR addresses -->
Closes #

## Type of change
- [ ] New feature (non-breaking change adding functionality)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] CI/CD / configuration change

## Changes made
<!-- List the key changes in this PR -->
- 

## Screenshots
<!-- If this PR includes UI changes, add a screenshot here -->

## Checklist
- [ ] Code builds without errors (`dotnet build`)
- [ ] All unit tests pass (`dotnet test`)
- [ ] No hardcoded secrets, connection strings, or API keys
- [ ] No `*.db` database files committed
- [ ] Linked to the relevant GitHub issue above
- [ ] Commit messages follow the `feat:` / `fix:` / `chore:` convention
